### PR TITLE
Improving the mask when the originals are upper and lower garments, and the target is a dress

### DIFF
--- a/leffa_utils/utils.py
+++ b/leffa_utils/utils.py
@@ -264,7 +264,10 @@ def get_agnostic_mask_dc(model_parse, keypoint, category, size=(384, 512)):
 
     if category == 'dresses':
         label_cat = 7
-        parse_mask = (parse_array == 7).astype(np.float32) + \
+        parse_mask = (parse_array == 4).astype(np.float32) + \
+            (parse_array == 5).astype(np.float32) + \
+            (parse_array == 6).astype(np.float32) + \
+            (parse_array == 7).astype(np.float32) + \
             (parse_array == 12).astype(np.float32) + \
             (parse_array == 13).astype(np.float32)
         parser_mask_changeable += np.logical_and(


### PR DESCRIPTION
Thanks for sharing your work. I have made a small modification to improve the try-on quality.

Right now, if the model type is DressCode, and the target category is a dress while the original is also a dress, the mask covers both the dress and the arms. However, when the originals are an upper and a lower garment, the mask only covers the arms because the dress does not exist. In that case, the mask should also include pants, skirts, and legs. Below is an illustration showing the results before and after the PR.

![99_visualized](https://github.com/user-attachments/assets/6bd0d834-46f4-445d-9ab0-406ebe2e0f6a)

Additionally, I confirmed that the behavior remains unchanged when the original is a dress. 

![99_visualized](https://github.com/user-attachments/assets/c43f7a53-229d-4831-a560-b14110bf0680)

Please let me know if there is something I should improve. Thanks!